### PR TITLE
Enhance uftrace with Offset-Based Filters and Nested Pointer Offset Triggers

### DIFF
--- a/libmcount/internal.h
+++ b/libmcount/internal.h
@@ -418,8 +418,8 @@ extern void mcount_arch_get_arg(struct mcount_arg_context *ctx, struct uftrace_a
 extern void mcount_arch_get_retval(struct mcount_arg_context *ctx, struct uftrace_arg_spec *spec);
 
 extern enum filter_result mcount_entry_filter_check(struct mcount_thread_data *mtdp,
-						    unsigned long child,
-						    struct uftrace_trigger *tr);
+						    unsigned long child, struct uftrace_trigger *tr,
+						    struct mcount_regs *regs);
 extern void mcount_entry_filter_record(struct mcount_thread_data *mtdp,
 				       struct mcount_ret_stack *rstack, struct uftrace_trigger *tr,
 				       struct mcount_regs *regs);

--- a/libmcount/mcount.c
+++ b/libmcount/mcount.c
@@ -222,6 +222,15 @@ static void mcount_signal_trigger(int sig)
 	}
 }
 
+static bool uftrace_eval_cond_with_context(struct uftrace_filter_cond *cond,
+					   struct mcount_arg_context *ctx)
+{
+	if (cond->off == -1) {
+		return uftrace_eval_cond(cond, &ctx->val.i);
+	}
+	return uftrace_eval_cond(cond, ctx->val.p);
+}
+
 /* clang-format off */
 #define SIGTABLE_ENTRY(s)  { #s, s }
 /* clang-format on */
@@ -1038,7 +1047,7 @@ enum filter_result mcount_entry_filter_check(struct mcount_thread_data *mtdp, un
 		mcount_arch_get_arg(&ctx, &spec);
 
 		/* keep the filter only if the condition is met */
-		if (!uftrace_eval_cond(&tr->cond, ctx.val.i))
+		if (!uftrace_eval_cond_with_context(&tr->cond, &ctx))
 			tr->flags &= ~TRIGGER_FL_FILTER;
 	}
 

--- a/libmcount/plthook.c
+++ b/libmcount/plthook.c
@@ -876,7 +876,7 @@ static unsigned long __plthook_entry(unsigned long *ret_addr, unsigned long chil
 		return 0;
 	}
 
-	filtered = mcount_entry_filter_check(mtdp, sym->addr, &tr);
+	filtered = mcount_entry_filter_check(mtdp, sym->addr, &tr, regs);
 	if (filtered != FILTER_IN) {
 		/*
 		 * Skip recording but still hook the return address,

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -36,6 +36,13 @@ static void snprintf_trigger_read(char *buf, size_t len, enum trigger_read_type 
 		snprintf(buf, len, "%s%s", buf[0] ? "|" : "", "pmu-branch");
 }
 
+static void snprintf_trigger_cond(char *buf, size_t len, struct uftrace_filter_cond *cond)
+{
+	const char *op_str[] = { "==", "!=", ">", ">=", "<", "<=" };
+
+	snprintf(buf, len, "arg%d %s %ld", cond->idx, op_str[cond->op], cond->val);
+}
+
 static void print_trigger(struct uftrace_trigger *tr)
 {
 	if (tr->flags & TRIGGER_FL_CLEAR)
@@ -44,9 +51,17 @@ static void print_trigger(struct uftrace_trigger *tr)
 		pr_dbg("\ttrigger: depth %d\n", tr->depth);
 	if (tr->flags & TRIGGER_FL_FILTER) {
 		if (tr->fmode == FILTER_MODE_IN)
-			pr_dbg("\ttrigger: filter IN\n");
+			pr_dbg("\ttrigger: filter IN");
 		else if (tr->fmode == FILTER_MODE_OUT)
-			pr_dbg("\ttrigger: filter OUT\n");
+			pr_dbg("\ttrigger: filter OUT");
+
+		if (tr->cond.idx) {
+			char buf[64];
+
+			snprintf_trigger_cond(buf, sizeof(buf), &tr->cond);
+			pr_dbg("\tif %s", buf);
+		}
+		pr_dbg("\n");
 	}
 	if (tr->flags & TRIGGER_FL_LOC) {
 		if (tr->lmode == FILTER_MODE_IN)
@@ -255,14 +270,18 @@ void update_trigger(struct uftrace_filter *filter, struct uftrace_trigger *tr, b
 
 	if (tr->flags & TRIGGER_FL_CLEAR) {
 		filter->trigger.flags &= ~tr->clear_flags;
-		if (tr->clear_flags & TRIGGER_FL_FILTER)
+		if (tr->clear_flags & TRIGGER_FL_FILTER) {
 			tr->fmode = filter->trigger.fmode; /* read from tree before deleting */
+			memset(&filter->trigger.cond, 0, sizeof(tr->cond));
+		}
 	}
 
 	if (tr->flags & TRIGGER_FL_DEPTH)
 		filter->trigger.depth = tr->depth;
-	if (tr->flags & TRIGGER_FL_FILTER)
+	if (tr->flags & TRIGGER_FL_FILTER) {
 		filter->trigger.fmode = tr->fmode;
+		memcpy(&filter->trigger.cond, &tr->cond, sizeof(tr->cond));
+	}
 	if (tr->flags & TRIGGER_FL_LOC)
 		filter->trigger.lmode = tr->lmode;
 
@@ -286,6 +305,26 @@ void update_trigger(struct uftrace_filter *filter, struct uftrace_trigger *tr, b
 		filter->trigger.read |= tr->read;
 	if (tr->flags & TRIGGER_FL_SIZE_FILTER)
 		filter->trigger.size = tr->size;
+}
+
+bool uftrace_eval_cond(struct uftrace_filter_cond *cond, long val)
+{
+	switch (cond->op) {
+	case FILTER_OP_EQ:
+		return val == cond->val;
+	case FILTER_OP_NE:
+		return val != cond->val;
+	case FILTER_OP_GT:
+		return val > cond->val;
+	case FILTER_OP_GE:
+		return val >= cond->val;
+	case FILTER_OP_LT:
+		return val < cond->val;
+	case FILTER_OP_LE:
+		return val <= cond->val;
+	default:
+		return false;
+	}
 }
 
 /**
@@ -744,6 +783,51 @@ static int parse_hide_action(char *action, struct uftrace_trigger *tr,
 	return 0;
 }
 
+/* if:arg1==1234, single condition only */
+static int parse_cond_action(char *action, struct uftrace_trigger *tr,
+			     struct uftrace_filter_setting *setting)
+{
+	const char *op_str[] = { "==", "!=", ">", ">=", "<", "<=" };
+	char *expr = action + 3;
+	char *pos;
+	int idx;
+	int op = -1;
+	long val;
+
+	if (strncmp(expr, "arg", 3)) {
+		pr_use("ignoring invalid arg: %s\n", expr);
+		return -1;
+	}
+
+	idx = strtol(expr + 3, &pos, 0);
+	if (idx < 1 || idx > 6) { /* don't support retval */
+		pr_use("only support up to 6 argument for now\n");
+		return -1;
+	}
+
+	/* reverse order match to find "<=" before "<" */
+	for (size_t k = ARRAY_SIZE(op_str) - 1; k < ARRAY_SIZE(op_str); k--) {
+		if (strncmp(pos, op_str[k], strlen(op_str[k])))
+			continue;
+
+		op = k;
+		pos += strlen(op_str[k]);
+		break;
+	}
+	if (op == -1) {
+		pr_use("ignoring invalid op: %.3s\n", pos);
+		return -1;
+	}
+
+	val = strtol(pos, NULL, 0);
+
+	tr->cond.idx = idx;
+	tr->cond.op = op;
+	tr->cond.val = val;
+
+	return 0;
+}
+
 static int parse_clear_action(char *action, struct uftrace_trigger *tr,
 			      struct uftrace_filter_setting *setting)
 {
@@ -894,6 +978,11 @@ static const struct trigger_action_parser actions[] = {
 		"clear",
 		parse_clear_action,
 		TRIGGER_FL_FILTER | TRIGGER_FL_CALLER,
+	},
+	{
+		"if:",
+		parse_cond_action,
+		TRIGGER_FL_FILTER,
 	},
 };
 
@@ -2566,6 +2655,126 @@ TEST_CASE(locfilter_match)
 
 	uftrace_cleanup_triggers(&triggers);
 	TEST_EQ(RB_EMPTY_ROOT(&triggers.root), true);
+
+	return TEST_OK;
+}
+
+TEST_CASE(filter_setup_cond)
+{
+	struct uftrace_trigger tr = {};
+	struct uftrace_filter_setting setting = {};
+	char val_str_ok1[] = "foo@filter,if:arg1==1234";
+	char val_str_ok2[] = "foo@filter,if:arg2!=100";
+	char val_str_ok3[] = "foo@filter,if:arg3>=5678";
+	char val_str_ok4[] = "foo@filter,if:arg4<9876";
+	char val_str_ng1[] = "foo@filter,if:name==1234"; /* named arg not supported */
+	char val_str_ng2[] = "foo@filter,if:fparg1==1234"; /* fparg not supported */
+	char val_str_ng3[] = "foo@filter,if:arg1~=1234"; /* op not supported */
+	char val_str_ng4[] = "foo@value,if:arg-1==1234"; /* negative arg index */
+	FILE *null_fp = fopen("/dev/null", "w");
+	FILE *saved_fp = outfp;
+
+	pr_dbg("check filter cond: %s\n", val_str_ok1);
+	TEST_EQ(setup_trigger_action(val_str_ok1, &tr, NULL, 0, &setting), 0);
+	TEST_EQ(tr.cond.idx, 1);
+	TEST_EQ(tr.cond.op, FILTER_OP_EQ);
+	TEST_EQ(tr.cond.val, 1234);
+
+	pr_dbg("check filter cond: %s\n", val_str_ok2);
+	TEST_EQ(setup_trigger_action(val_str_ok2, &tr, NULL, 0, &setting), 0);
+	TEST_EQ(tr.cond.idx, 2);
+	TEST_EQ(tr.cond.op, FILTER_OP_NE);
+	TEST_EQ(tr.cond.val, 100);
+
+	pr_dbg("check filter cond: %s\n", val_str_ok3);
+	TEST_EQ(setup_trigger_action(val_str_ok3, &tr, NULL, 0, &setting), 0);
+	TEST_EQ(tr.cond.idx, 3);
+	TEST_EQ(tr.cond.op, FILTER_OP_GE);
+	TEST_EQ(tr.cond.val, 5678);
+
+	pr_dbg("check filter cond: %s\n", val_str_ok4);
+	TEST_EQ(setup_trigger_action(val_str_ok4, &tr, NULL, 0, &setting), 0);
+	TEST_EQ(tr.cond.idx, 4);
+	TEST_EQ(tr.cond.op, FILTER_OP_LT);
+	TEST_EQ(tr.cond.val, 9876);
+
+	memset(&tr, 0, sizeof(tr));
+	/* suppress usage error messages */
+	if (!debug)
+		outfp = null_fp;
+
+	TEST_NE(setup_trigger_action(val_str_ng1, &tr, NULL, 0, &setting), 0);
+	TEST_NE(setup_trigger_action(val_str_ng2, &tr, NULL, 0, &setting), 0);
+	TEST_NE(setup_trigger_action(val_str_ng3, &tr, NULL, 0, &setting), 0);
+	TEST_NE(setup_trigger_action(val_str_ng4, &tr, NULL, 0, &setting), 0);
+
+	if (!debug)
+		outfp = saved_fp;
+
+	/* failed function should not set any fields */
+	TEST_EQ(tr.cond.idx, 0);
+	TEST_EQ(tr.cond.op, 0);
+	TEST_EQ(tr.cond.val, 0);
+
+	return TEST_OK;
+}
+
+TEST_CASE(filter_eval_cond)
+{
+	struct uftrace_filter_cond cond;
+
+	pr_dbg("check filter cond: arg == 1\n");
+	cond.op = FILTER_OP_EQ;
+	cond.val = 1;
+
+	TEST_EQ(uftrace_eval_cond(&cond, 1), true);
+	TEST_EQ(uftrace_eval_cond(&cond, 2), false);
+
+	pr_dbg("check filter cond: arg == -1\n");
+	cond.op = FILTER_OP_EQ;
+	cond.val = -1;
+
+	TEST_EQ(uftrace_eval_cond(&cond, 1), false);
+	TEST_EQ(uftrace_eval_cond(&cond, -1), true);
+
+	pr_dbg("check filter cond: arg != 1\n");
+	cond.op = FILTER_OP_NE;
+	cond.val = 1;
+
+	TEST_EQ(uftrace_eval_cond(&cond, 1), false);
+	TEST_EQ(uftrace_eval_cond(&cond, 0), true);
+
+	pr_dbg("check filter cond: arg > 10\n");
+	cond.op = FILTER_OP_GT;
+	cond.val = 10;
+
+	TEST_EQ(uftrace_eval_cond(&cond, 11), true);
+	TEST_EQ(uftrace_eval_cond(&cond, 10), false);
+	TEST_EQ(uftrace_eval_cond(&cond, -1), false);
+
+	pr_dbg("check filter cond: arg >= 10\n");
+	cond.op = FILTER_OP_GE;
+	cond.val = 10;
+
+	TEST_EQ(uftrace_eval_cond(&cond, 11), true);
+	TEST_EQ(uftrace_eval_cond(&cond, 10), true);
+	TEST_EQ(uftrace_eval_cond(&cond, 9), false);
+
+	pr_dbg("check filter cond: arg < 0\n");
+	cond.op = FILTER_OP_LT;
+	cond.val = 0;
+
+	TEST_EQ(uftrace_eval_cond(&cond, 1), false);
+	TEST_EQ(uftrace_eval_cond(&cond, 0), false);
+	TEST_EQ(uftrace_eval_cond(&cond, -1), true);
+
+	pr_dbg("check filter cond: arg <= 0\n");
+	cond.op = FILTER_OP_LE;
+	cond.val = 0;
+
+	TEST_EQ(uftrace_eval_cond(&cond, 1), false);
+	TEST_EQ(uftrace_eval_cond(&cond, 0), true);
+	TEST_EQ(uftrace_eval_cond(&cond, -1), true);
 
 	return TEST_OK;
 }

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -40,7 +40,30 @@ static void snprintf_trigger_cond(char *buf, size_t len, struct uftrace_filter_c
 {
 	const char *op_str[] = { "==", "!=", ">", ">=", "<", "<=" };
 
-	snprintf(buf, len, "arg%d %s %ld", cond->idx, op_str[cond->op], cond->val);
+	if (cond->off == -1) {
+		// Direct value comparison: e.g., "arg1 == 1234"
+		// cond->val is a malloc'd block of size sizeof(long)
+		long val;
+		memcpy(&val, cond->val, sizeof(long)); // Copy the value from cond->val
+		snprintf(buf, len, "arg%d %s %ld", cond->idx, op_str[cond->op], val);
+	}
+	else {
+		// Memory block comparison: e.g., "arg1+4:2 == 0x1234"
+		char hex_str[cond->size * 2 + 3]; // 2 chars per byte + "0x" + null terminator
+		unsigned char *bytes = (unsigned char *)cond->val;
+		int pos = 0;
+
+		// Build hex string: "0x" prefix followed by bytes
+		pos += snprintf(hex_str + pos, sizeof(hex_str) - pos, "0x");
+		for (int i = 0; i < cond->size; i++) {
+			pos += snprintf(hex_str + pos, sizeof(hex_str) - pos, "%02" PRIX8,
+					bytes[i]);
+		}
+
+		// Format the full condition string
+		snprintf(buf, len, "arg%d+%d:%d %s %s", cond->idx, cond->off, cond->size,
+			 op_str[cond->op], hex_str);
+	}
 }
 
 static void print_trigger(struct uftrace_trigger *tr)
@@ -307,21 +330,28 @@ void update_trigger(struct uftrace_filter *filter, struct uftrace_trigger *tr, b
 		filter->trigger.size = tr->size;
 }
 
-bool uftrace_eval_cond(struct uftrace_filter_cond *cond, long val)
+bool uftrace_eval_cond(struct uftrace_filter_cond *cond, void *val)
 {
 	switch (cond->op) {
 	case FILTER_OP_EQ:
-		return val == cond->val;
+		return memcmp(val + cond->off, cond->val, cond->size) == 0;
 	case FILTER_OP_NE:
-		return val != cond->val;
+		return memcmp(val + cond->off, cond->val, cond->size) != 0;
 	case FILTER_OP_GT:
-		return val > cond->val;
+		return memcmp(val + cond->off, cond->val, cond->size) > 0;
 	case FILTER_OP_GE:
-		return val >= cond->val;
+		return memcmp(val + cond->off, cond->val, cond->size) >= 0;
 	case FILTER_OP_LT:
-		return val < cond->val;
+		return memcmp(val + cond->off, cond->val, cond->size) < 0;
 	case FILTER_OP_LE:
-		return val <= cond->val;
+		return memcmp(val + cond->off, cond->val, cond->size) <= 0;
+	case FILTER_OP_BETWEEN: {
+		long v;
+		struct uftrace_filter_between_cond *bp = cond->val;
+
+		memcpy(&v, val + cond->off, sizeof(long));
+		return v >= bp->l && v <= bp->h;
+	}
 	default:
 		return false;
 	}
@@ -783,16 +813,21 @@ static int parse_hide_action(char *action, struct uftrace_trigger *tr,
 	return 0;
 }
 
-/* if:arg1==1234, single condition only */
+/*
+ * if:arg1==1234, single condition
+ * if:args1+0:2==0x1234, memory condition
+ * if:args1+0:2<>1:2, range condition
+ */
 static int parse_cond_action(char *action, struct uftrace_trigger *tr,
 			     struct uftrace_filter_setting *setting)
 {
-	const char *op_str[] = { "==", "!=", ">", ">=", "<", "<=" };
+	const char *op_str[] = { "==", "!=", ">", ">=", "<", "<=", "--" };
 	char *expr = action + 3;
 	char *pos;
 	int idx;
 	int op = -1;
-	long val;
+	int off = -1; /* default direct value */
+	int size = 0;
 
 	if (strncmp(expr, "arg", 3)) {
 		pr_use("ignoring invalid arg: %s\n", expr);
@@ -803,6 +838,31 @@ static int parse_cond_action(char *action, struct uftrace_trigger *tr,
 	if (idx < 1 || idx > 6) { /* don't support retval */
 		pr_use("only support up to 6 argument for now\n");
 		return -1;
+	}
+
+	/* check for optional "+offset:size" syntax */
+	if (*pos == '+') {
+		char *tmp;
+
+		off = strtol(pos + 1, &tmp, 0);
+		if (tmp == pos + 1 || off < 0) {
+			pr_use("ignoring invalid offset: %s\n", pos + 1);
+			return -1;
+		}
+		pos = tmp;
+		if (*pos != ':') {
+			pr_use("ignoring invalid size: %s\n", pos + 1);
+			return -1;
+		}
+		size = strtol(pos + 1, &tmp, 0);
+		if (tmp == pos + 1 || size < 0) {
+			pr_use("ignoring invalid size: %s\n", pos + 1);
+			return -1;
+		}
+		pos = tmp;
+	}
+	else {
+		size = sizeof(long);
 	}
 
 	/* reverse order match to find "<=" before "<" */
@@ -819,11 +879,62 @@ static int parse_cond_action(char *action, struct uftrace_trigger *tr,
 		return -1;
 	}
 
-	val = strtol(pos, NULL, 0);
+	if ((tr->cond.val = malloc(size)) == NULL) {
+		pr_err("malloc failed\n");
+		return -1;
+	}
+	if (op == FILTER_OP_BETWEEN) {
+		char *tmp;
+		long l, h;
+		struct uftrace_filter_between_cond *bp;
+
+		l = strtol(pos, &tmp, 0);
+		if (tmp == pos || l < 0) {
+			pr_use("ignoring invalid range low value: %s\n", pos);
+			return -1;
+		}
+		pos = tmp;
+		if (*pos != ':') {
+			pr_use("ignoring invalid range value: %s\n", pos + 1);
+			return -1;
+		}
+		h = strtol(pos + 1, &tmp, 0);
+		if (tmp == pos + 1 || h < 0) {
+			pr_use("ignoring invalid range high value: %s\n", pos + 1);
+			return -1;
+		}
+		pos = tmp;
+		if ((tr->cond.val = realloc(tr->cond.val,
+					    sizeof(struct uftrace_filter_between_cond))) == NULL) {
+			pr_err("realloc failed\n");
+			return -1;
+		}
+		bp = tr->cond.val;
+		bp->l = l;
+		bp->h = h;
+	}
+	else if (off >= 0) {
+		/* skip 0x prefix */
+		if (strncmp(pos, "0x", 2) == 0) {
+			pos += 2;
+		}
+		if (strlen(pos) != (size_t)size * 2) {
+			pr_use("ignoring invalid value: %s\n", pos);
+			return -1;
+		}
+		for (int i = 0; i < size; i++) {
+			sscanf(pos + i * 2, "%2hhx", &((unsigned char *)tr->cond.val)[i]);
+		}
+	}
+	else {
+		long val = strtol(pos, NULL, 0);
+		memcpy(tr->cond.val, &val, size);
+	}
 
 	tr->cond.idx = idx;
+	tr->cond.off = off;
 	tr->cond.op = op;
-	tr->cond.val = val;
+	tr->cond.size = size;
 
 	return 0;
 }

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -1,5 +1,6 @@
 #include <fnmatch.h>
 #include <regex.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/utsname.h>
@@ -16,6 +17,17 @@
 #include "utils/rbtree.h"
 #include "utils/symbol.h"
 #include "utils/utils.h"
+
+static void *get_pointer_data(void *ptr, int num_off, int *ptr_off)
+{
+	int i;
+	void *data = ptr;
+
+	for (i = 0; i < num_off; i++) {
+		data = *(void **)(data + ptr_off[i]);
+	}
+	return data;
+}
 
 static void snprintf_trigger_read(char *buf, size_t len, enum trigger_read_type type)
 {
@@ -348,8 +360,28 @@ bool uftrace_eval_cond(struct uftrace_filter_cond *cond, void *val)
 	case FILTER_OP_BETWEEN: {
 		long v;
 		struct uftrace_filter_between_cond *bp = cond->val;
+		void *data = get_pointer_data(val, cond->num_off, cond->ptr_off) + cond->off;
 
-		memcpy(&v, val + cond->off, sizeof(long));
+		if (cond->size == 1) {
+			uint8_t u8_v;
+			memcpy(&u8_v, data, cond->size);
+			v = (long)u8_v;
+		}
+		else if (cond->size == 2) {
+			uint16_t u16_v;
+			memcpy(&u16_v, data, sizeof(uint16_t));
+			v = (long)u16_v;
+		}
+		else if (cond->size == 4) {
+			uint32_t u32_v;
+			memcpy(&u32_v, data, sizeof(uint32_t));
+			v = (long)u32_v;
+		}
+		else {
+			uint64_t u64_v;
+			memcpy(&u64_v, data, sizeof(uint64_t));
+			v = (long)u64_v;
+		}
 		return v >= bp->l && v <= bp->h;
 	}
 	default:
@@ -816,18 +848,23 @@ static int parse_hide_action(char *action, struct uftrace_trigger *tr,
 /*
  * if:arg1==1234, single condition
  * if:args1+0:2==0x1234, memory condition
- * if:args1+0:2<>1:2, range condition
+ * if:args1+0:2--1:2, range condition
+ * if:arg1+8+16+0:2--1:2, multi-level pointer offset with range
  */
 static int parse_cond_action(char *action, struct uftrace_trigger *tr,
 			     struct uftrace_filter_setting *setting)
 {
 	const char *op_str[] = { "==", "!=", ">", ">=", "<", "<=", "--" };
+	const int size_list[] = { 0, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1,
+				  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
 	char *expr = action + 3;
 	char *pos;
 	int idx;
 	int op = -1;
 	int off = -1; /* default direct value */
 	int size = 0;
+	int num_off = 0;
+	int *ptr_off = NULL;
 
 	if (strncmp(expr, "arg", 3)) {
 		pr_use("ignoring invalid arg: %s\n", expr);
@@ -840,26 +877,47 @@ static int parse_cond_action(char *action, struct uftrace_trigger *tr,
 		return -1;
 	}
 
-	/* check for optional "+offset:size" syntax */
-	if (*pos == '+') {
+	// read the [+offset] part
+	while (*pos == '+') {
 		char *tmp;
 
-		off = strtol(pos + 1, &tmp, 0);
-		if (tmp == pos + 1 || off < 0) {
+		int offset = strtol(pos + 1, &tmp, 0);
+		if (tmp == pos + 1 || offset < 0) {
 			pr_use("ignoring invalid offset: %s\n", pos + 1);
+			free(ptr_off);
 			return -1;
 		}
 		pos = tmp;
-		if (*pos != ':') {
-			pr_use("ignoring invalid size: %s\n", pos + 1);
+		if ((ptr_off = realloc(ptr_off, (num_off + 1) * sizeof(int))) == NULL) {
+			pr_err("realloc failed\n");
+			free(ptr_off);
 			return -1;
 		}
+		ptr_off[num_off++] = offset;
+		if (*pos == ':')
+			break;
+	}
+
+	if (num_off > 0) {
+		num_off--;
+		off = ptr_off[num_off];
+	}
+
+	if (*pos == ':') {
+		char *tmp;
+
 		size = strtol(pos + 1, &tmp, 0);
 		if (tmp == pos + 1 || size < 0) {
 			pr_use("ignoring invalid size: %s\n", pos + 1);
+			free(ptr_off);
 			return -1;
 		}
 		pos = tmp;
+		if (size >= (int)sizeof(size_list) || size_list[size] == 0) {
+			pr_use("ignoring invalid size: %d\n", size);
+			free(ptr_off);
+			return -1;
+		}
 	}
 	else {
 		size = sizeof(long);
@@ -876,11 +934,13 @@ static int parse_cond_action(char *action, struct uftrace_trigger *tr,
 	}
 	if (op == -1) {
 		pr_use("ignoring invalid op: %.3s\n", pos);
+		free(ptr_off);
 		return -1;
 	}
 
 	if ((tr->cond.val = malloc(size)) == NULL) {
 		pr_err("malloc failed\n");
+		free(ptr_off);
 		return -1;
 	}
 	if (op == FILTER_OP_BETWEEN) {
@@ -891,22 +951,26 @@ static int parse_cond_action(char *action, struct uftrace_trigger *tr,
 		l = strtol(pos, &tmp, 0);
 		if (tmp == pos || l < 0) {
 			pr_use("ignoring invalid range low value: %s\n", pos);
+			free(ptr_off);
 			return -1;
 		}
 		pos = tmp;
 		if (*pos != ':') {
 			pr_use("ignoring invalid range value: %s\n", pos + 1);
+			free(ptr_off);
 			return -1;
 		}
 		h = strtol(pos + 1, &tmp, 0);
 		if (tmp == pos + 1 || h < 0) {
 			pr_use("ignoring invalid range high value: %s\n", pos + 1);
+			free(ptr_off);
 			return -1;
 		}
 		pos = tmp;
 		if ((tr->cond.val = realloc(tr->cond.val,
 					    sizeof(struct uftrace_filter_between_cond))) == NULL) {
 			pr_err("realloc failed\n");
+			free(ptr_off);
 			return -1;
 		}
 		bp = tr->cond.val;
@@ -920,6 +984,7 @@ static int parse_cond_action(char *action, struct uftrace_trigger *tr,
 		}
 		if (strlen(pos) != (size_t)size * 2) {
 			pr_use("ignoring invalid value: %s\n", pos);
+			free(ptr_off);
 			return -1;
 		}
 		for (int i = 0; i < size; i++) {
@@ -935,6 +1000,8 @@ static int parse_cond_action(char *action, struct uftrace_trigger *tr,
 	tr->cond.off = off;
 	tr->cond.op = op;
 	tr->cond.size = size;
+	tr->cond.num_off = num_off;
+	tr->cond.ptr_off = ptr_off;
 
 	return 0;
 }

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -65,6 +65,21 @@ enum trigger_read_type {
 	TRIGGER_READ_PMU_BRANCH = 16,
 };
 
+enum filter_cond_op {
+	FILTER_OP_EQ,
+	FILTER_OP_NE,
+	FILTER_OP_GT,
+	FILTER_OP_GE,
+	FILTER_OP_LT,
+	FILTER_OP_LE,
+};
+
+struct uftrace_filter_cond {
+	int idx; /* argument index, 0 if disabled */
+	enum filter_cond_op op;
+	long val;
+};
+
 struct uftrace_trigger {
 	enum trigger_flag flags;
 	enum trigger_flag clear_flags;
@@ -75,6 +90,7 @@ struct uftrace_trigger {
 	enum filter_mode fmode;
 	enum filter_mode lmode;
 	enum trigger_read_type read;
+	struct uftrace_filter_cond cond;
 	struct list_head *pargs;
 };
 
@@ -163,6 +179,8 @@ void uftrace_cleanup_filter(struct rb_root *root);
 void uftrace_cleanup_triggers(struct uftrace_triggers_info *triggers);
 void uftrace_print_filter(struct rb_root *root);
 int uftrace_count_filter(struct rb_root *root, unsigned long flag);
+
+bool uftrace_eval_cond(struct uftrace_filter_cond *cond, long val);
 
 void init_filter_pattern(enum uftrace_pattern_type type, struct uftrace_pattern *p, char *str);
 bool match_filter_pattern(struct uftrace_pattern *p, char *name);

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -4,6 +4,8 @@
 #include <regex.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "utils/arch.h"
 #include "utils/argspec.h"
@@ -72,12 +74,20 @@ enum filter_cond_op {
 	FILTER_OP_GE,
 	FILTER_OP_LT,
 	FILTER_OP_LE,
+	FILTER_OP_BETWEEN,
+};
+
+struct uftrace_filter_between_cond {
+	long l;
+	long h;
 };
 
 struct uftrace_filter_cond {
 	int idx; /* argument index, 0 if disabled */
+	int off; /* byte offset for memory comparison, -1 if direct value */
+	int size; /* size of the data in bytes for memory comparison */
 	enum filter_cond_op op;
-	long val;
+	void *val; /* pointer to the value */
 };
 
 struct uftrace_trigger {
@@ -180,7 +190,7 @@ void uftrace_cleanup_triggers(struct uftrace_triggers_info *triggers);
 void uftrace_print_filter(struct rb_root *root);
 int uftrace_count_filter(struct rb_root *root, unsigned long flag);
 
-bool uftrace_eval_cond(struct uftrace_filter_cond *cond, long val);
+bool uftrace_eval_cond(struct uftrace_filter_cond *cond, void *val);
 
 void init_filter_pattern(enum uftrace_pattern_type type, struct uftrace_pattern *p, char *str);
 bool match_filter_pattern(struct uftrace_pattern *p, char *name);

--- a/utils/filter.h
+++ b/utils/filter.h
@@ -87,6 +87,8 @@ struct uftrace_filter_cond {
 	int off; /* byte offset for memory comparison, -1 if direct value */
 	int size; /* size of the data in bytes for memory comparison */
 	enum filter_cond_op op;
+	int num_off; // number of pointer offsets
+	int *ptr_off; // array of pointer offsets
 	void *val; /* pointer to the value */
 };
 

--- a/utils/fstack.c
+++ b/utils/fstack.c
@@ -519,7 +519,7 @@ int fstack_setup_filters(struct uftrace_opts *opts, struct uftrace_data *handle)
 
 		if (setup_fstack_filters(handle, opts->filter, opts->trigger, opts->caller,
 					 opts->hide, opts->loc_filter, &setting) < 0) {
-			char * or = "";
+			char *or = "";
 			pr_use("failed to set filter or trigger: ");
 			if (opts->filter) {
 				pr_out("%s%s", or, opts->filter);
@@ -661,14 +661,14 @@ int fstack_entry(struct uftrace_task_reader *task, struct uftrace_record *rstack
 			struct list_head *arg_list = task->args.args;
 			struct uftrace_arg_spec *spec;
 			void *data = task->args.data;
-			long val = 0;
+			void *val = NULL;
 			bool found = false;
 
 			list_for_each_entry(spec, arg_list, list) {
 				int size = spec->size;
 
 				if (spec->idx == tr->cond.idx) {
-					memcpy(&val, data, spec->size);
+					val = data;
 					found = true;
 					break;
 				}


### PR DESCRIPTION
# Overview

This pull request introduces two significant enhancements to `uftrace` to improve its conditional tracing capabilities:

1. **Offset-based equality and range filters**: Extends the filter syntax to support memory offset checks within pointer arguments.
2. **Nested pointer offset triggers**: Adds support for multi-level pointer dereferencing in `@if` triggers for nested struct access.

These changes enable more flexible and precise tracing of functions based on complex argument conditions, making `uftrace` more powerful for debugging and performance analysis.

